### PR TITLE
Branch b fixed duration tasks

### DIFF
--- a/src/main/java/duke/command/StartTaskCommand.java
+++ b/src/main/java/duke/command/StartTaskCommand.java
@@ -1,0 +1,43 @@
+package duke.command;
+
+import duke.task.Task;
+import duke.task.FixedDurationTask;
+import duke.util.TaskList;
+import duke.util.Ui;
+import duke.util.Storage;
+import duke.util.DukeException;
+
+public class StartTaskCommand implements Command {
+
+    private final int index;
+    private final String startAt;
+
+    public StartTaskCommand(int index, String startAt) {
+        this.index = index;
+        this.startAt = startAt;
+    }
+
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) {
+        try {
+            Task task = tasks.get(index - 1);
+            if (!(task instanceof FixedDurationTask)) {
+                throw new DukeException("That is not a fixed duration task!");
+            }
+            FixedDurationTask fixedDurationTask = (FixedDurationTask) task;
+            fixedDurationTask.setStartDateTimeFromString(startAt);
+            storage.update(tasks.getList());
+            String msg = ui.getSuccessMessage("start", task);
+            ui.sendMessage(msg);
+            return msg;
+        } catch (DukeException e) {
+            ui.sendMessage(e.getMessage());
+            return e.getMessage();
+        }
+    }
+}

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -23,10 +23,10 @@ public class Deadline extends TaskWithDateTime {
     @Override
     public String toString() {
         String dt = String.format(" (by: %s",
-                date.format(DateTimeFormatter.ofPattern("MMM d yyyy")));
+                date.format(DateTimeFormatter.ofPattern("d MMM")));
         if (time.isPresent()) {
             dt += String.format(", %s)",
-                    time.get().format(DateTimeFormatter.ofPattern("hh:mm a")));
+                    time.get().format(DateTimeFormatter.ofPattern("h:mm a")));
         } else {
             dt += ")";
         }

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -23,10 +23,10 @@ public class Event extends TaskWithDateTime {
     @Override
     public String toString() {
         String dt = String.format(" (at: %s",
-                date.format(DateTimeFormatter.ofPattern("MMM d yyyy")));
+                date.format(DateTimeFormatter.ofPattern("d MMM")));
         if (time.isPresent()) {
             dt += String.format(", %s)",
-                    time.get().format(DateTimeFormatter.ofPattern("hh:mm a")));
+                    time.get().format(DateTimeFormatter.ofPattern("h:mm a")));
         } else {
             dt += ")";
         }

--- a/src/main/java/duke/task/FixedDurationTask.java
+++ b/src/main/java/duke/task/FixedDurationTask.java
@@ -7,6 +7,7 @@ import duke.util.DukeException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.Duration;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
 
@@ -25,6 +26,13 @@ public class FixedDurationTask extends Task {
     public FixedDurationTask(String description, String duration) {
         super("F", description);
         this.duration = parseDuration(duration);
+        startDate = Optional.empty();
+        startTime = Optional.empty();
+    }
+
+    public FixedDurationTask(String description, long durationSeconds) {
+        super("F", description);
+        this.duration = Duration.ofSeconds(durationSeconds);
         startDate = Optional.empty();
         startTime = Optional.empty();
     }
@@ -50,6 +58,7 @@ public class FixedDurationTask extends Task {
         if (temp[0].contains("h")) {
             hour = Integer.parseInt(temp[0].split("h")[0]);
             if (temp.length > 1 && temp[1].contains("m")) {
+                System.out.println("Contains m");
                 minute = Integer.parseInt(temp[1].split("m")[0]);
             } else {
                 minute = 0;
@@ -101,4 +110,23 @@ public class FixedDurationTask extends Task {
         return LocalTime.parse(timeString);
     }
 
+    @Override
+    public String getDescription() {
+        return String.format("%s / %s / %s %s", description, duration.getSeconds(),
+                startDate.map(LocalDate::toString).orElse(""),
+                startTime.map(LocalTime::toString).orElse(""));
+    }
+
+    @Override
+    public String toString() {
+        String info = "";
+        if (startDate.isPresent() && startTime.isPresent()) {
+            info += String.format(" (start: %s, %s)",
+                    startDate.get().format(DateTimeFormatter.ofPattern("d MMM")),
+                    startTime.get().format(DateTimeFormatter.ofPattern("h:mm a")));
+        }
+        long sec = duration.getSeconds();
+        info += String.format(" (for: %dh %dm)", sec / 3600, (sec % 3600) / 60);
+        return super.toString() + info;
+    }
 }

--- a/src/main/java/duke/task/FixedDurationTask.java
+++ b/src/main/java/duke/task/FixedDurationTask.java
@@ -1,0 +1,104 @@
+// TODO: AddCommand add FixedDurationTask; Parser; StartTaskCommand; HelpCommand Ui
+
+package duke.task;
+
+import duke.util.DukeException;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+
+/**
+ * The fixed duration task has two main states; task with duration without a
+ * specified start date time, and task with duration and specified start date time.
+ * This allows users to create a task without a decided start date time and they
+ * are free to provide the start date time in the future.
+ */
+public class FixedDurationTask extends Task {
+
+    private Optional<LocalDate> startDate;
+    private Optional<LocalTime> startTime;
+    private final Duration duration;
+
+    public FixedDurationTask(String description, String duration) {
+        super("F", description);
+        this.duration = parseDuration(duration);
+        startDate = Optional.empty();
+        startTime = Optional.empty();
+    }
+
+    /**
+     * Parses the user input string into a duration for the task.
+     * This duration object will be stored in the task and used to
+     * generate the start time and end time of a particular date once
+     * the date time information is provided by the user.
+     * Example:
+     *     "1h 10m" -> PT1H10M
+     *     "2h" -> PT2H
+     *     "160m" -> PT2H40M
+     * Users have some freedom in choosing whether or not the hour
+     * or minute should be included.
+     * @param raw the user input to be parsed.
+     * @return the duration of the task.
+     */
+    public Duration parseDuration(String raw) {
+        String[] temp = raw.toLowerCase().split(" ");
+        int hour;
+        int minute;
+        if (temp[0].contains("h")) {
+            hour = Integer.parseInt(temp[0].split("h")[0]);
+            if (temp.length > 1 && temp[1].contains("m")) {
+                minute = Integer.parseInt(temp[1].split("m")[0]);
+            } else {
+                minute = 0;
+            }
+        } else {
+            hour = 0;
+            minute = Integer.parseInt(temp[0].split("m")[0]);
+        }
+        return Duration.ofMinutes((long) (60 * hour) + minute);
+    }
+
+    /**
+     * Sets the start date and time of the task from the user input.
+     * This will mutate the task to provide a start time and end time
+     * information whenever it is being displayed.
+     * @param dateTime the user input containing the date and time.
+     */
+    public void setStartDateTimeFromString(String dateTime) throws DukeException {
+        try {
+            String[] dateTimeSplit = dateTime.split(" ");
+            LocalDate date = parseDate(dateTimeSplit[0]);
+            LocalTime time = parseTime(dateTimeSplit[1]);
+            setStartDateTime(date, time);
+        } catch (DateTimeParseException de) {
+            throw new DukeException("Invalid date or time format!");
+        } catch (ArrayIndexOutOfBoundsException aioobe) {
+            throw new DukeException("Missing date or time!");
+        }
+    }
+
+    public void setStartDateTime(LocalDate date, LocalTime time) {
+        startDate = Optional.of(date);
+        startTime = Optional.of(time);
+    }
+
+    private LocalDate parseDate(String raw) {
+        if (raw.equals("today")) {
+            return LocalDate.now();
+        } else if (raw.equals("tomorrow")) {
+            return LocalDate.now().plusDays(1);
+        }
+        return LocalDate.parse(raw.replaceAll("/", "-"));
+    }
+
+    private LocalTime parseTime(String raw) {
+        String timeString = String.format("%1$" + 5 + "s",
+                raw.replace(".", ":"))
+                .replace(" ", "0");
+        return LocalTime.parse(timeString);
+    }
+
+}

--- a/src/main/java/duke/task/TaskWithDateTime.java
+++ b/src/main/java/duke/task/TaskWithDateTime.java
@@ -4,7 +4,6 @@ import duke.util.DukeException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
 

--- a/src/main/java/duke/util/Parser.java
+++ b/src/main/java/duke/util/Parser.java
@@ -10,6 +10,7 @@ import duke.command.ExitCommand;
 import duke.command.InvalidCommand;
 import duke.command.HelpCommand;
 import duke.command.SortCommand;
+import duke.command.StartTaskCommand;
 
 import java.util.Arrays;
 
@@ -74,6 +75,7 @@ public class Parser {
         case "todo":
         case "event":
         case "deadline":
+        case "fixed":
             String description = Parser.getTaskDescription(parsed);
             return new AddCommand(command, description);
         case "done":
@@ -114,6 +116,15 @@ public class Parser {
                 return new SortCommand(parsed[1]);
             } catch (ArrayIndexOutOfBoundsException aioobe) {
                 return new InvalidCommand("You can sort by: name, type, datetime");
+            }
+        case "start":
+            try {
+                int taskNumber = Integer.parseInt(parsed[1]);
+                return new StartTaskCommand(taskNumber, parsed[2] + " " + parsed[3]);
+            } catch (ArrayIndexOutOfBoundsException aioobe) {
+                return new InvalidCommand();
+            } catch (NumberFormatException nfe) {
+                throw new DukeException("Invalid task number!");
             }
         default:
             return new InvalidCommand();

--- a/src/main/java/duke/util/Storage.java
+++ b/src/main/java/duke/util/Storage.java
@@ -4,6 +4,7 @@ import duke.task.Task;
 import duke.task.Todo;
 import duke.task.Event;
 import duke.task.Deadline;
+import duke.task.FixedDurationTask;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -71,7 +72,7 @@ public class Storage {
             Scanner sc = new Scanner(file);
             while (sc.hasNext()) {
                 String[] t = sc.nextLine().split(",");
-                assert List.of("T", "E", "D").contains(t[0]) : "Subtype should be T, E, or D only";
+                assert List.of("T", "E", "D", "F").contains(t[0]) : "Subtype should be T, E, F, or D only";
 
                 switch (t[0]) {
                 case "T":
@@ -82,6 +83,16 @@ public class Storage {
                     break;
                 case "E":
                     list.add(new Event(t[2], t[3], t[1].equals("1")));
+                    break;
+                case "F":
+                    FixedDurationTask fdt = new FixedDurationTask(t[2], Integer.parseInt(t[3]));
+                    if (t[1].equals("1")) {
+                        fdt.markAsDone();
+                    }
+                    if (t.length > 4) {
+                        fdt.setStartDateTimeFromString(t[4]);
+                    }
+                    list.add(fdt);
                     break;
                 default:
                     throw new DukeException("Corrupted file, previous data will not be loaded!");
@@ -104,14 +115,15 @@ public class Storage {
         try {
             FileWriter fw = new FileWriter(file);
             for (Task t: list) {
-                String toWrite = String.format("%s,%s", t.getType(), (t.getDone() ? "1" : "0"));
+                StringBuilder toWrite = new StringBuilder(
+                        String.format("%s,%s", t.getType(), (t.getDone() ? "1" : "0")));
                 String desc = t.getDescription();
-                if (List.of("D", "E").contains(t.getType())) {
+                if (List.of("D", "E", "F").contains(t.getType())) {
+                    toWrite.append(",");
                     String[] descSplit = desc.split(" / ");
-                    toWrite += "," + descSplit[descSplit.length - 2];
-                    toWrite += "," + descSplit[descSplit.length - 1];
+                    toWrite.append(String.join(",", descSplit));
                 } else {
-                    toWrite += "," + desc;
+                    toWrite.append(",").append(desc);
                 }
                 fw.write(toWrite + "\n");
             }

--- a/src/main/java/duke/util/TaskList.java
+++ b/src/main/java/duke/util/TaskList.java
@@ -1,10 +1,6 @@
 package duke.util;
 
-import duke.task.Task;
-import duke.task.TaskWithDateTime;
-import duke.task.Todo;
-import duke.task.Event;
-import duke.task.Deadline;
+import duke.task.*;
 
 import java.util.List;
 import java.util.ArrayList;
@@ -102,6 +98,15 @@ public class TaskList {
                 throw new DukeException("Invalid " + type + " description!");
             }
             break;
+        case "fixed":
+            try {
+                split = description.split(" /for ");
+                desc = split[0];
+                String duration = split[1];
+                task = new FixedDurationTask(desc, duration);
+            } catch (IndexOutOfBoundsException ioobe) {
+                throw new DukeException("Invalid " + type + " description!");
+            }
         }
         return task;
     }

--- a/src/main/java/duke/util/Ui.java
+++ b/src/main/java/duke/util/Ui.java
@@ -125,8 +125,8 @@ public class Ui {
      */
     public String getSuccessMessage(String type, Task task) throws DukeException {
         StringBuilder sb = new StringBuilder("Okay I've ");
-        assert List.of("add", "remove", "done").contains(type)
-                : "Task manipulation type can only be one of [add, remove, done].";
+        assert List.of("add", "remove", "done", "start").contains(type)
+                : "Task manipulation type can only be one of [add, remove, done, start].";
         switch(type) {
         case "add":
             sb.append("added:");
@@ -137,6 +137,9 @@ public class Ui {
         case "done":
             sb.append("marked this task as done:");
             break;
+        case "start":
+            sb.append("set this task's start date time:");
+            break;
         default:
             throw new DukeException("Unrecognized task manipulation type!");
         }
@@ -145,12 +148,14 @@ public class Ui {
     }
 
     public String getListOfCommands() {
-        String[] commands = new String[] {
+        String[] commands = new String[]{
                 "help", "list", "todo <description>",
                 "event <description> /at <date> [time]",
                 "deadline <description> /by <date> [time]",
-                "done <task number>", "remove <task number>",
-                "remove all", "sort <name/type/datetime>", "bye"
+                "fixed <description> /for <duration>",
+                "done <task no.>", "remove <task no.>",
+                "remove all", "sort <name/type/datetime>",
+                "start <task no.> <date> <time>", "bye"
         };
         StringBuilder sb = new StringBuilder("Here are the available commands:\n");
         for (String command: commands) {

--- a/src/main/java/duke/util/Ui.java
+++ b/src/main/java/duke/util/Ui.java
@@ -150,7 +150,7 @@ public class Ui {
                 "event <description> /at <date> [time]",
                 "deadline <description> /by <date> [time]",
                 "done <task number>", "remove <task number>",
-                "remove all", "bye"
+                "remove all", "sort <name/type/datetime>", "bye"
         };
         StringBuilder sb = new StringBuilder("Here are the available commands:\n");
         for (String command: commands) {


### PR DESCRIPTION
**Fixed Duration Tasks**

Have you ever had tasks that have very clear duration but the start date time are not fixed yet?
Introducing `FixedDurationTask.java`!
    - Debuting `Duration` class
    - Special appearance: `Optional`
    - Comes in two states: Duration without start datetime, Duration with start datetime
    - Different states different `toString()`!!!

Usage:
```
>> fixed cry in a corner /for 2h
1. [F][0] cry in a corner (for: 2h 0m)

>> start 1 today 14:00
1. [F][0] cry in a corner (start: 9 Sep, 2:00 pm) (for: 2h 0m)

>> done 1
1. [F][1] cry in a corner (start: 9 Sep, 2:00 pm) (for: 2h 0m)
```

LGTY? LGTM.